### PR TITLE
Properly support Quadruple Buffering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ include $(DEVKITPRO)/libnx/switch_rules
 #   NACP building is skipped as well.
 #---------------------------------------------------------------------------------
 APP_TITLE	:=	FPSLocker
-APP_VERSION	:=	1.2.2
+APP_VERSION	:=	1.2.3
 
 TARGET		:=	FPSLocker
 BUILD		:=	build


### PR DESCRIPTION
Now in games using Quadruple Buffering it will be possible to set Triple Buffering next to Double Buffering. 

Example of game: Assassin's Creed The Ezio Collection.

And also now when saving settings with different buffering than Double Buffering Window Sync will be always saved as Enabled.